### PR TITLE
adding adm as an optional group for the splunk user

### DIFF
--- a/splunkforwarder/user.sls
+++ b/splunkforwarder/user.sls
@@ -8,5 +8,7 @@ splunk_user:
     - home: /opt/splunkforwarder
     - groups:
       - splunk
+    - optional_groups:
+      - adm
     - require:
       - group: splunk_group


### PR DESCRIPTION
This is to eliminate errors that we're seeing where the state that adds splunk to adm is conflicting with this state. @ross-p 
